### PR TITLE
Updated README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To make things even easier, this repo also includes:
 
 You can run the container like so:
 
-    docker run -d -p 8000 mhowlett/ngx-stub-status-prometheus
+    docker run -d -p 8000:8000 mhowlett/ngx-stub-status-prometheus
 
 This starts up nginx with a test configuration. If you browse to http://127.0.0.1:8000/metrics you should see the status information.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To cut a long story short:
 1. ./fetch-nginx.sh
 2. ./docker-up.sh
 3. cd /repo
-4. /build.sh
+4. ./build.sh
 5. /usr/sbin/nginx -c /repo/nginx.conf
 
 

--- a/docker-up.sh
+++ b/docker-up.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -it -p 8000:8000 -v /git/ngx_stub_status_prometheus:/repo mhowlett/nginx-build-base /bin/bash
+docker run --rm -it -p 8000:8000 -v $PWD/:/repo mhowlett/nginx-build-base /bin/bash


### PR DESCRIPTION
In README file, there is a docker run command to create the docker container. 
$ docker run -d -p 8000 mhowlett/ngx-stub-status-prometheus
This command exposes the container port 8000 but it does not bind local port 8000 to container. So when user tries to access http://127.0.0.1:8000/metrics URL, it does not work. As by default docker takes some random local port and binds it to container's 8000 port.